### PR TITLE
Align link icons justified at both ends

### DIFF
--- a/src/components/Links.tsx
+++ b/src/components/Links.tsx
@@ -6,7 +6,7 @@ export default function Links() {
     return (
         <>
             <div className="rounded-lg w-full">
-                <div className="gap-x-6 gap-y-8 flex flex-wrap">
+                <div className="gap-y-8 flex flex-wrap justify-between">
                     <div className="w-24 h-16">
                         <a href="https://x.com/yude_jp">
                             <FontAwesomeIcon className="w-24 h-11" icon={faXTwitter} />


### PR DESCRIPTION
リンクのアイコンの右側が揃っておらず、見苦しいので両端を揃えます。伴って、アイコン同士がすこし寄ってしまうかもしれません。

Before:
![image](https://github.com/yudejp/yude.jp/assets/48670724/08245baa-47b3-45b7-aea6-66819c595574)

After:
![image](https://github.com/yudejp/yude.jp/assets/48670724/e056d242-6eae-4a5d-98d1-cc009d3b0f27)
