### PR TITLE
Fix 古いリンクから yude.jp に飛んだときに画像が壊れる  (#4)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,10 @@ export default function App() {
   };
 
   useEffect(() => {
+    if (window.location.pathname !== '/') {
+      window.history.replaceState(null, '', '/');
+    }
+
     handleScroll();
     
     const mutualElm = document.getElementById("mutuals");

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -49,7 +49,7 @@ export default function Card() {
                         className="rounded-full hover:cursor-grab"
                         width={100}
                         height={100}
-                        src="./avatar.webp"
+                        src="/avatar.webp"
                     />
                 </div>
                 <div className="mx-2 text-left h-full inline-block">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,8 +1,8 @@
 export default function Footer() {
     return (
         <div className="text-center text-gray-500 mb-5">
-            <img src="./banner_new.png" className="h-12 inline" />
-            <img src="./busy_banner.webp" className="h-12 inline" />
+            <img src="/banner_new.png" className="h-12 inline" />
+            <img src="/busy_banner.webp" className="h-12 inline" />
             <img src="https://moe-counter-cf.yude.workers.dev/yude.jp:home" className="h-20 mx-auto" />
             <p className="mt-5">
                 <a href="https://github.com/yudejp/yude.jp">

--- a/src/components/Links.tsx
+++ b/src/components/Links.tsx
@@ -57,7 +57,7 @@ export default function Links() {
                     </div>
                     <div className="w-24 h-16">
                         <a href="https://scrapbox.io/yude">
-                            <img src="./logo/scrapbox.svg" className="w-24 h-12 grayscale" />
+                            <img src="/logo/scrapbox.svg" className="w-24 h-12 grayscale" />
                             <span className="block text-gray-400 text-center">
                                 Scrapbox
                             </span>
@@ -65,7 +65,7 @@ export default function Links() {
                     </div>
                     <div className="w-24 h-16">
                         <a href="https://zenn.dev/yude">
-                            <img src="./logo/zenn.svg" className="w-24 h-12 text-center invert" />
+                            <img src="/logo/zenn.svg" className="w-24 h-12 text-center invert" />
                             <span className="block text-gray-400 text-center">
                                 Zenn
                             </span>
@@ -73,7 +73,7 @@ export default function Links() {
                     </div>
                     <div className="w-24 h-16">
                         <a href="https://yudejp.hatenablog.jp">
-                            <img src="./logo/hatenablog.svg" className="w-24 h-12 text-center invert" />
+                            <img src="/logo/hatenablog.svg" className="w-24 h-12 text-center invert" />
                             <span className="block text-gray-400">
                                 はてなブログ
                             </span>
@@ -81,7 +81,7 @@ export default function Links() {
                     </div>
                     <div className="w-24 h-16">
                         <a href="https://sizu.me/yude">
-                            <img src="./logo/sizume.svg" className="w-24 h-12 text-center invert" />
+                            <img src="/logo/sizume.svg" className="w-24 h-12 text-center invert" />
                             <span className="block text-gray-400 text-center">
                                 しずかなインターネット
                             </span>
@@ -121,7 +121,7 @@ export default function Links() {
                     </div>
                     <div className="w-24 h-16">
                         <a href="https://annict.com/yude">
-                            <img src="./logo/annict.png" className="w-12 h-12 ml-6 grayscale" />
+                            <img src="/logo/annict.png" className="w-12 h-12 ml-6 grayscale" />
                             <span className="block text-gray-400 text-center">
                                 Annict
                             </span>
@@ -129,7 +129,7 @@ export default function Links() {
                     </div>
                     <div className="w-24 h-16">
                         <a href="https://vrcprofile.com/p/yude">
-                            <img src="./logo/vrchat.png" className="w-12 ml-6 mt-5" />
+                            <img src="/logo/vrchat.png" className="w-12 ml-6 mt-5" />
                             <span className="block text-gray-400 text-center mt-2">
                                 VRChat
                             </span>

--- a/src/components/Mutuals.tsx
+++ b/src/components/Mutuals.tsx
@@ -2,34 +2,34 @@ export default function Mutuals() {
     return (
         <div className="text-center text-gray-500 mb-5">
             <a href="https://arkw.net">
-                <img src="./mutual-links/arkwnet.png" className="h-12 inline" />
+                <img src="/mutual-links/arkwnet.png" className="h-12 inline" />
             </a>
             <a href="https://exout.net/~kirby3ds/">
-                <img src="./mutual-links/kirby3ds.png" className="h-12 inline" />
+                <img src="/mutual-links/kirby3ds.png" className="h-12 inline" />
             </a>
             <a href="https://kris.fail">
-                <img src="./mutual-links/kris_fail.png" className="h-12 inline" />
+                <img src="/mutual-links/kris_fail.png" className="h-12 inline" />
             </a>
             <a href="https://kusaremkn.com">
-                <img src="./mutual-links/kusaremkn.webp" className="h-12 inline" />
+                <img src="/mutual-links/kusaremkn.webp" className="h-12 inline" />
             </a>
             <a href="https://nona-takahara.github.io/">
-                <img src="./mutual-links/nona-takahara.png" className="h-12 inline" />
+                <img src="/mutual-links/nona-takahara.png" className="h-12 inline" />
             </a>
             <a href="https://www.pepepper.net">
-                <img src="./mutual-links/pepepper.png" className="h-12 inline" />
+                <img src="/mutual-links/pepepper.png" className="h-12 inline" />
             </a>
             <a href="https://qqey.net">
-                <img src="./mutual-links/qqeynet.png" className="h-12 inline" />
+                <img src="/mutual-links/qqeynet.png" className="h-12 inline" />
             </a>
             <a href="https://sasakulab.com">
-                <img src="./mutual-links/sasakulab.png" className="h-12 inline" />
+                <img src="/mutual-links/sasakulab.png" className="h-12 inline" />
             </a>
             <a href="https://nullc.at/">
-                <img src="./mutual-links/nullcat.png" className="h-12 inline" />
+                <img src="/mutual-links/nullcat.png" className="h-12 inline" />
             </a>
             <a href="https://yank-nvim.com/">
-                <img src="./mutual-links/yank-nvim.png" className="h-12 inline" />
+                <img src="/mutual-links/yank-nvim.png" className="h-12 inline" />
             </a>
             <a href="https://zopfco.de/">
                 <span
@@ -67,7 +67,7 @@ export default function Mutuals() {
                 </span>
             </a>
             <a href="https://hieri.vercel.app">
-            <img src="./mutual-links/hieri.png" className="h-12 inline" />
+            <img src="/mutual-links/hieri.png" className="h-12 inline" />
             </a>
             <a href="https://rz7.dev">
                 <span


### PR DESCRIPTION
この Pull Request は「古いリンクから yude.jp に飛んだときに画像が壊れる (#4)」を解決します。

- 恐らく推奨されているパス名 '/' 以外としてアクセスされた場合にパス名を '/' に書き換えます。リダイレクトではありません。
- 画像を絶対パスで指定することでパス名 '/' 以外からアクセスされた場合にも画像を正しく表示します。