### PR TITLE
Fix aspect ratio of banners

### DIFF
--- a/src/components/Mutuals.tsx
+++ b/src/components/Mutuals.tsx
@@ -1,8 +1,8 @@
 import Marquee from "react-fast-marquee";
 
 export default function Mutuals() {
-    const noImageBanner = `border border-4 border-fuchsia-300 bg-slate-200 pt-1.5 px-3 text-black h-12 font-bold block min-w-56 text-center text-2xl font-serif`
-    const globalBanner = `h-12 inline-block`
+    const noImageBanner = `border border-4 border-fuchsia-300 bg-slate-200 pt-1.5 px-3 text-black h-12 font-bold block min-w-32 text-center text-2xl font-serif`
+    const globalBanner = `h-12 w-auto inline-block`
 
     return (
         <Marquee


### PR DESCRIPTION
画像の存在するバナーについては明示的に横幅を自動設定するように指定することで本来のアスペクト比を維持し、画像の存在しないバナーについては最小の幅を修正することで適切な幅を得られるようになりました